### PR TITLE
Intruduce FilterAPIView and & APIVew of Course, Lecture, College, Department, Major

### DIFF
--- a/backend/crawler/crawler.py
+++ b/backend/crawler/crawler.py
@@ -41,7 +41,7 @@ def run(crawler):
         driver.find_element_by_xpath('//*[@id="srchOpenSchyy"]').send_keys(crawler.year)
         driver.implicitly_wait(1)
         driver.find_element_by_xpath('//*[@id="srchOpenShtm"]/option[{}]'.format(sid[crawler.semester])).click()
-        driver.implicitly_wait(10)
+        driver.implicitly_wait(1)
         driver.find_element_by_xpath('//*[@id="srchOpenSubmattCorsFg"]/option[2]').click()
         driver.implicitly_wait(1)
         driver.find_element_by_class_name('btn_search_ok').click()

--- a/backend/crawler/crawler.py
+++ b/backend/crawler/crawler.py
@@ -41,7 +41,7 @@ def run(crawler):
         driver.find_element_by_xpath('//*[@id="srchOpenSchyy"]').send_keys(crawler.year)
         driver.implicitly_wait(1)
         driver.find_element_by_xpath('//*[@id="srchOpenShtm"]/option[{}]'.format(sid[crawler.semester])).click()
-        driver.implicitly_wait(1)
+        driver.implicitly_wait(10)
         driver.find_element_by_xpath('//*[@id="srchOpenSubmattCorsFg"]/option[2]').click()
         driver.implicitly_wait(1)
         driver.find_element_by_class_name('btn_search_ok').click()

--- a/backend/ttrs/serializers.py
+++ b/backend/ttrs/serializers.py
@@ -21,11 +21,6 @@ class StudentSerializer(serializers.ModelSerializer):
             raise ValidationError("The host must be 'snu.ac.kr'.")
         return email
 
-    def validate_grade(self, grade):
-        if grade not in range(1, 5):
-            raise ValidationError("The grade must be a integer of 1~4")
-        return grade
-
     def get_field_value(self, data, key):
         if key in data:
             return data[key]

--- a/backend/ttrs/serializers.py
+++ b/backend/ttrs/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from django.core.exceptions import ValidationError as DjangoValidationError
 
-from .models import Student, College, Department, Major, Course
+from .models import Student, College, Department, Major, Course, Lecture
 
 
 class StudentSerializer(serializers.ModelSerializer):
@@ -64,6 +64,12 @@ class StudentSerializer(serializers.ModelSerializer):
 class CourseSerializer(serializers.ModelSerializer):
     class Meta:
         model = Course
+        fields = '__all__'
+
+
+class LectureSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Lecture
         fields = '__all__'
 
 

--- a/backend/ttrs/serializers.py
+++ b/backend/ttrs/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from django.core.exceptions import ValidationError as DjangoValidationError
 
-from .models import Student, College, Department
+from .models import Student, College, Department, Major
 
 
 class StudentSerializer(serializers.ModelSerializer):
@@ -71,3 +71,14 @@ class DepartmentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Department
         fields = '__all__'
+
+
+class MajorSerializer(serializers.ModelSerializer):
+    college = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Major
+        fields = '__all__'
+
+    def get_college(self, major):
+        return major.department.college_id

--- a/backend/ttrs/serializers.py
+++ b/backend/ttrs/serializers.py
@@ -82,3 +82,11 @@ class MajorSerializer(serializers.ModelSerializer):
 
     def get_college(self, major):
         return major.department.college_id
+
+
+class CollegeDetailSerializer(CollegeSerializer):
+    departments = DepartmentSerializer(many=True, read_only=True)
+
+
+class DepartmentDetailSerializer(DepartmentSerializer):
+    majors = MajorSerializer(many=True, read_only=True)

--- a/backend/ttrs/serializers.py
+++ b/backend/ttrs/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from django.core.exceptions import ValidationError as DjangoValidationError
 
-from .models import Student
+from .models import Student, College
 
 
 class StudentSerializer(serializers.ModelSerializer):
@@ -17,7 +17,7 @@ class StudentSerializer(serializers.ModelSerializer):
         }
 
     def validate_email(self, email):
-        if email.split('@')[1] !='snu.ac.kr':
+        if email.split('@')[1] != 'snu.ac.kr':
             raise ValidationError("The host must be 'snu.ac.kr'.")
         return email
 
@@ -59,3 +59,9 @@ class StudentSerializer(serializers.ModelSerializer):
             raise ValidationError({'password': ve.messages})
         data['password'] = make_password(data['password'])
         return data
+
+
+class CollegeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = College
+        fields = '__all__'

--- a/backend/ttrs/serializers.py
+++ b/backend/ttrs/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from django.core.exceptions import ValidationError as DjangoValidationError
 
-from .models import Student, College, Department, Major
+from .models import Student, College, Department, Major, Course
 
 
 class StudentSerializer(serializers.ModelSerializer):
@@ -59,6 +59,12 @@ class StudentSerializer(serializers.ModelSerializer):
             raise ValidationError({'password': ve.messages})
         data['password'] = make_password(data['password'])
         return data
+
+
+class CourseSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Course
+        fields = '__all__'
 
 
 class CollegeSerializer(serializers.ModelSerializer):

--- a/backend/ttrs/serializers.py
+++ b/backend/ttrs/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from django.core.exceptions import ValidationError as DjangoValidationError
 
-from .models import Student, College
+from .models import Student, College, Department
 
 
 class StudentSerializer(serializers.ModelSerializer):
@@ -64,4 +64,10 @@ class StudentSerializer(serializers.ModelSerializer):
 class CollegeSerializer(serializers.ModelSerializer):
     class Meta:
         model = College
+        fields = '__all__'
+
+
+class DepartmentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Department
         fields = '__all__'

--- a/backend/ttrs/urls.py
+++ b/backend/ttrs/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path('students/<int:pk>/', views.StudentDetail.as_view()),
     path('colleges/', views.CollegeList.as_view()),
     path('departments/', views.DepartmentList.as_view()),
+    path('majors/', views.MajorList.as_view()),
 ]

--- a/backend/ttrs/urls.py
+++ b/backend/ttrs/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from rest_framework.urlpatterns import format_suffix_patterns
 
 from . import views
 
@@ -16,3 +17,5 @@ urlpatterns = [
     path('majors/', views.MajorList.as_view()),
     path('majors/<int:pk>/', views.MajorDetail.as_view()),
 ]
+
+urlpatterns += format_suffix_patterns(urlpatterns)

--- a/backend/ttrs/urls.py
+++ b/backend/ttrs/urls.py
@@ -6,6 +6,9 @@ urlpatterns = [
     path('students/', views.StudentList.as_view()),
     path('students/<int:pk>/', views.StudentDetail.as_view()),
     path('colleges/', views.CollegeList.as_view()),
+    path('colleges/<int:pk>/', views.CollegeDetail.as_view()),
     path('departments/', views.DepartmentList.as_view()),
+    path('departments/<int:pk>/', views.DepartmentDetail.as_view()),
     path('majors/', views.MajorList.as_view()),
+    path('majors/<int:pk>/', views.MajorDetail.as_view()),
 ]

--- a/backend/ttrs/urls.py
+++ b/backend/ttrs/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('courses/', views.CourseList.as_view()),
     path('courses/<int:pk>/', views.CourseDetail.as_view()),
     path('lectures/', views.LectureList.as_view()),
+    path('lectures/<int:pk>/', views.LectureDetail.as_view()),
 
     path('colleges/', views.CollegeList.as_view()),
     path('colleges/<int:pk>/', views.CollegeDetail.as_view()),

--- a/backend/ttrs/urls.py
+++ b/backend/ttrs/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
 
     path('courses/', views.CourseList.as_view()),
     path('courses/<int:pk>/', views.CourseDetail.as_view()),
+    path('lectures/', views.LectureList.as_view()),
 
     path('colleges/', views.CollegeList.as_view()),
     path('colleges/<int:pk>/', views.CollegeDetail.as_view()),

--- a/backend/ttrs/urls.py
+++ b/backend/ttrs/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('students/<int:pk>/', views.StudentDetail.as_view()),
 
     path('courses/', views.CourseList.as_view()),
+    path('courses/<int:pk>/', views.CourseDetail.as_view()),
 
     path('colleges/', views.CollegeList.as_view()),
     path('colleges/<int:pk>/', views.CollegeDetail.as_view()),

--- a/backend/ttrs/urls.py
+++ b/backend/ttrs/urls.py
@@ -5,4 +5,5 @@ from . import views
 urlpatterns = [
     path('students/', views.StudentList.as_view()),
     path('students/<int:pk>/', views.StudentDetail.as_view()),
+    path('colleges/', views.CollegeList.as_view()),
 ]

--- a/backend/ttrs/urls.py
+++ b/backend/ttrs/urls.py
@@ -5,6 +5,9 @@ from . import views
 urlpatterns = [
     path('students/', views.StudentList.as_view()),
     path('students/<int:pk>/', views.StudentDetail.as_view()),
+
+    path('courses/', views.CourseList.as_view()),
+
     path('colleges/', views.CollegeList.as_view()),
     path('colleges/<int:pk>/', views.CollegeDetail.as_view()),
     path('departments/', views.DepartmentList.as_view()),

--- a/backend/ttrs/urls.py
+++ b/backend/ttrs/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path('students/', views.StudentList.as_view()),
     path('students/<int:pk>/', views.StudentDetail.as_view()),
     path('colleges/', views.CollegeList.as_view()),
+    path('departments/', views.DepartmentList.as_view()),
 ]

--- a/backend/ttrs/views.py
+++ b/backend/ttrs/views.py
@@ -3,30 +3,22 @@ from rest_framework.permissions import IsAuthenticated
 
 from .permissions import IsTheStudent
 from .serializers import StudentSerializer, CollegeSerializer, DepartmentSerializer, MajorSerializer, \
-    CollegeDetailSerializer, DepartmentDetailSerializer, CourseSerializer
-from .models import Student, College, Department, Major, Course
+    CollegeDetailSerializer, DepartmentDetailSerializer, CourseSerializer, LectureSerializer
+from .models import Student, College, Department, Major, Course, Lecture
 
 
 class FilterAPIView(generics.GenericAPIView):
     """
     Supporting custom APIView class for filtering queryset based on query_params.
 
-    Extend this class and set 'filter_options', a class variable of 'tuple'
-    which defines list of keys you want to filter.
-    Each element of 'filter_options' must be valid key for function 'QuerySet.filter'.
-
-    Note: Default 'filter_options' is empty, therefore it filters nothing.
+    By extend this class, the APIView will automatically filter queryset if the request
+    has query_params.
+    Keys of the query_params MUST be a valid key of the function 'QuerySet.filter', or
+    that param will be ignored.
     """
 
-    filter_options = ()
-
     def get_queryset(self):
-        filter_kwargs = {}
-        for option in self.filter_options:
-            value = self.request.query_params.get(option, None)
-            if value is not None:
-                filter_kwargs[option] = value
-        return self.queryset.filter(**filter_kwargs)
+        return self.queryset.filter(**self.request.query_params.dict())
 
 
 class StudentList(generics.ListCreateAPIView):
@@ -45,12 +37,17 @@ class CourseList(FilterAPIView, generics.ListAPIView):
     queryset = Course.objects.all()
     serializer_class = CourseSerializer
     permission_classes = (IsAuthenticated,)
-    filter_options = ('code', 'name', 'type', 'field', 'grade', 'credit', 'college_id', 'department_id', 'major_id')
 
 
 class CourseDetail(generics.RetrieveAPIView):
     queryset = Course.objects.all()
     serializer_class = CourseSerializer
+    permission_classes = (IsAuthenticated,)
+
+
+class LectureList(FilterAPIView, generics.ListAPIView):
+    queryset = Lecture.objects.all().filter()
+    serializer_class = LectureSerializer
     permission_classes = (IsAuthenticated,)
 
 
@@ -70,7 +67,6 @@ class DepartmentList(FilterAPIView, generics.ListAPIView):
     queryset = Department.objects.all()
     serializer_class = DepartmentSerializer
     permission_classes = (IsAuthenticated,)
-    filter_options = ('college_id',)
 
 
 class DepartmentDetail(generics.RetrieveAPIView):
@@ -83,7 +79,6 @@ class MajorList(FilterAPIView, generics.ListAPIView):
     queryset = Major.objects.all()
     serializer_class = MajorSerializer
     permission_classes = (IsAuthenticated,)
-    filter_options = ('department__college_id', 'department_id')
 
 
 class MajorDetail(generics.RetrieveAPIView):

--- a/backend/ttrs/views.py
+++ b/backend/ttrs/views.py
@@ -48,6 +48,12 @@ class CourseList(FilterAPIView, generics.ListAPIView):
     filter_options = ('code', 'name', 'type', 'field', 'grade', 'credit', 'college_id', 'department_id', 'major_id')
 
 
+class CourseDetail(generics.RetrieveAPIView):
+    queryset = Course.objects.all()
+    serializer_class = CourseSerializer
+    permission_classes = (IsAuthenticated,)
+
+
 class CollegeList(generics.ListAPIView):
     queryset = College.objects.all()
     serializer_class = CollegeSerializer

--- a/backend/ttrs/views.py
+++ b/backend/ttrs/views.py
@@ -5,8 +5,8 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 
 from .permissions import IsTheStudent
-from .serializers import StudentSerializer
-from .models import Student
+from .serializers import StudentSerializer, CollegeSerializer
+from .models import Student, College
 
 
 class StudentList(generics.ListCreateAPIView):
@@ -33,3 +33,9 @@ class StudentDetail(generics.RetrieveUpdateDestroyAPIView):
             instance._prefetched_objects_cache = {}
 
         return Response(serializer.data)
+
+
+class CollegeList(generics.ListAPIView):
+    queryset = College.objects.all()
+    serializer_class = CollegeSerializer
+    permission_classes = (IsAuthenticated,)

--- a/backend/ttrs/views.py
+++ b/backend/ttrs/views.py
@@ -1,12 +1,10 @@
-from django.forms import model_to_dict
-from django.http import QueryDict
 from rest_framework import generics
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 
 from .permissions import IsTheStudent
-from .serializers import StudentSerializer, CollegeSerializer, DepartmentSerializer
-from .models import Student, College, Department
+from .serializers import StudentSerializer, CollegeSerializer, DepartmentSerializer, MajorSerializer
+from .models import Student, College, Department, Major
 
 
 class StudentList(generics.ListCreateAPIView):
@@ -44,4 +42,10 @@ class CollegeList(generics.ListAPIView):
 class DepartmentList(generics.ListAPIView):
     queryset = Department.objects.all()
     serializer_class = DepartmentSerializer
+    permission_classes = (IsAuthenticated,)
+
+
+class MajorList(generics.ListAPIView):
+    queryset = Major.objects.all()
+    serializer_class = MajorSerializer
     permission_classes = (IsAuthenticated,)

--- a/backend/ttrs/views.py
+++ b/backend/ttrs/views.py
@@ -5,8 +5,8 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 
 from .permissions import IsTheStudent
-from .serializers import StudentSerializer, CollegeSerializer
-from .models import Student, College
+from .serializers import StudentSerializer, CollegeSerializer, DepartmentSerializer
+from .models import Student, College, Department
 
 
 class StudentList(generics.ListCreateAPIView):
@@ -38,4 +38,10 @@ class StudentDetail(generics.RetrieveUpdateDestroyAPIView):
 class CollegeList(generics.ListAPIView):
     queryset = College.objects.all()
     serializer_class = CollegeSerializer
+    permission_classes = (IsAuthenticated,)
+
+
+class DepartmentList(generics.ListAPIView):
+    queryset = Department.objects.all()
+    serializer_class = DepartmentSerializer
     permission_classes = (IsAuthenticated,)

--- a/backend/ttrs/views.py
+++ b/backend/ttrs/views.py
@@ -46,7 +46,13 @@ class CourseDetail(generics.RetrieveAPIView):
 
 
 class LectureList(FilterAPIView, generics.ListAPIView):
-    queryset = Lecture.objects.all().filter()
+    queryset = Lecture.objects.all()
+    serializer_class = LectureSerializer
+    permission_classes = (IsAuthenticated,)
+
+
+class LectureDetail(generics.RetrieveAPIView):
+    queryset = Lecture.objects.all()
     serializer_class = LectureSerializer
     permission_classes = (IsAuthenticated,)
 

--- a/backend/ttrs/views.py
+++ b/backend/ttrs/views.py
@@ -3,7 +3,8 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 
 from .permissions import IsTheStudent
-from .serializers import StudentSerializer, CollegeSerializer, DepartmentSerializer, MajorSerializer
+from .serializers import StudentSerializer, CollegeSerializer, DepartmentSerializer, MajorSerializer, \
+    CollegeDetailSerializer, DepartmentDetailSerializer
 from .models import Student, College, Department, Major
 
 
@@ -39,13 +40,31 @@ class CollegeList(generics.ListAPIView):
     permission_classes = (IsAuthenticated,)
 
 
+class CollegeDetail(generics.RetrieveAPIView):
+    queryset = College.objects.all()
+    serializer_class = CollegeDetailSerializer
+    permission_classes = (IsAuthenticated,)
+
+
 class DepartmentList(generics.ListAPIView):
     queryset = Department.objects.all()
     serializer_class = DepartmentSerializer
     permission_classes = (IsAuthenticated,)
 
 
+class DepartmentDetail(generics.RetrieveAPIView):
+    queryset = Department.objects.all()
+    serializer_class = DepartmentDetailSerializer
+    permission_classes = (IsAuthenticated,)
+
+
 class MajorList(generics.ListAPIView):
+    queryset = Major.objects.all()
+    serializer_class = MajorSerializer
+    permission_classes = (IsAuthenticated,)
+
+
+class MajorDetail(generics.RetrieveAPIView):
     queryset = Major.objects.all()
     serializer_class = MajorSerializer
     permission_classes = (IsAuthenticated,)

--- a/backend/ttrs/views.py
+++ b/backend/ttrs/views.py
@@ -1,11 +1,32 @@
 from rest_framework import generics
-from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 
 from .permissions import IsTheStudent
 from .serializers import StudentSerializer, CollegeSerializer, DepartmentSerializer, MajorSerializer, \
-    CollegeDetailSerializer, DepartmentDetailSerializer
-from .models import Student, College, Department, Major
+    CollegeDetailSerializer, DepartmentDetailSerializer, CourseSerializer
+from .models import Student, College, Department, Major, Course
+
+
+class FilterAPIView(generics.GenericAPIView):
+    """
+    Supporting custom APIView class for filtering queryset based on query_params.
+
+    Extend this class and set 'filter_options', a class variable of 'tuple'
+    which defines list of keys you want to filter.
+    Each element of 'filter_options' must be valid key for function 'QuerySet.filter'.
+
+    Note: Default 'filter_options' is empty, therefore it filters nothing.
+    """
+
+    filter_options = ()
+
+    def get_queryset(self):
+        filter_kwargs = {}
+        for option in self.filter_options:
+            value = self.request.query_params.get(option, None)
+            if value is not None:
+                filter_kwargs[option] = value
+        return self.queryset.filter(**filter_kwargs)
 
 
 class StudentList(generics.ListCreateAPIView):
@@ -19,19 +40,12 @@ class StudentDetail(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = StudentSerializer
     permission_classes = (IsAuthenticated, IsTheStudent)
 
-    def update(self, request, *args, **kwargs):
-        partial = kwargs.pop('partial', False)
-        instance = self.get_object()
-        serializer = self.get_serializer(instance, data=request.data, partial=partial)
-        serializer.is_valid(raise_exception=True)
-        self.perform_update(serializer)
 
-        if getattr(instance, '_prefetched_objects_cache', None):
-            # If 'prefetch_related' has been applied to a queryset, we need to
-            # forcibly invalidate the prefetch cache on the instance.
-            instance._prefetched_objects_cache = {}
-
-        return Response(serializer.data)
+class CourseList(FilterAPIView, generics.ListAPIView):
+    queryset = Course.objects.all()
+    serializer_class = CourseSerializer
+    permission_classes = (IsAuthenticated,)
+    filter_options = ('code', 'name', 'type', 'field', 'grade', 'credit', 'college_id', 'department_id', 'major_id')
 
 
 class CollegeList(generics.ListAPIView):
@@ -46,10 +60,11 @@ class CollegeDetail(generics.RetrieveAPIView):
     permission_classes = (IsAuthenticated,)
 
 
-class DepartmentList(generics.ListAPIView):
+class DepartmentList(FilterAPIView, generics.ListAPIView):
     queryset = Department.objects.all()
     serializer_class = DepartmentSerializer
     permission_classes = (IsAuthenticated,)
+    filter_options = ('college_id',)
 
 
 class DepartmentDetail(generics.RetrieveAPIView):
@@ -58,10 +73,11 @@ class DepartmentDetail(generics.RetrieveAPIView):
     permission_classes = (IsAuthenticated,)
 
 
-class MajorList(generics.ListAPIView):
+class MajorList(FilterAPIView, generics.ListAPIView):
     queryset = Major.objects.all()
     serializer_class = MajorSerializer
     permission_classes = (IsAuthenticated,)
+    filter_options = ('department__college_id', 'department_id')
 
 
 class MajorDetail(generics.RetrieveAPIView):


### PR DESCRIPTION
## FilterAPIView
**`FilterAPIView`** is custom APIView for filtering instances.

For example,

When sending request like,
```json
GET /lectures/?course__name__contains=알고
```
The query_params will be,
```json
{
   "course__name__contains": "알고"
}
```
And we can receive a response like,
```json
HTTP 200 OK
[
    {
        "id": 2170,
        "year": 2018,
        "semester": "1학기",
        "number": "002",
        "instructor": "김선",
        "note": "ⓔ®컴퓨터공학부 주전공 및 제2전공생만 수강가능, 자료구조 수강 필수",
        "course": 1185,
        "time_slots": [
            3446,
            3447
        ]
    },
    {
        "id": 5302,
        "year": 2016,
        "semester": "1학기",
        "number": "002",
        "instructor": "김선",
        "note": "ⓔ®컴퓨터공학부 주전공 및 제2전공생만 수강가능, 자료구조 수강 필수",
        "course": 1185,
        "time_slots": [
            8097,
            8098
        ]
    }
]
```
We can get Lectures of Course 1185, which has properties like,
```json
{
    "id": 1185,
    "code": "4190.407",
    "name": "알고리즘",
    "type": "전필",
    "field": null,
    "grade": 3,
    "credit": 3,
    "college": 3,
    "department": 6,
    "major": null
}
```

In this case, FilterAPIView behavioured as if it used the code below,
```python3
def get_queryset(self):
    return Lecture.objects.filter(course__name__contains=알고)
```

Of course, there are a lot of keys besides `course__name__contains`
For the specification of keys used in `QuerySet.filter`, you can refer to [this section](https://docs.djangoproject.com/en/2.0/ref/models/querysets/#filter)

My **`FilterAPIView`** maps query_params (extracted from the request) to keys of `QuerySet.filter`.

There might be mutliple query_params.

Let's see another example.
Request is,
```json
GET /lectures/?course__department__name=컴퓨터공학부&year=2018&semester=1학기&course__credit=1
```
The query_params will be,
```json
{
    "course__department__name": "컴퓨터공학부",
    "year": "2018",
    "semester": "1학기",
    "course__credit": "1",
}
```
Response will be,
```json
HTTP 200 OK
[
    {
        "id": 2097,
        "year": 2018,
        "semester": "1학기",
        "number": "001",
        "instructor": "신영길",
        "note": "®컴퓨터공학부 주전공 및 제2전공생만 수강가능",
        "course": 1120,
        "time_slots": [
            3310
        ]
    },
    {
        "id": 2173,
        "year": 2018,
        "semester": "1학기",
        "number": "001",
        "instructor": "신영길",
        "note": "®컴퓨터공학부 주전공 및 제2전공생만 수강가능",
        "course": 1188,
        "time_slots": [
            3452
        ]
    }
]
```

The course 1188 and 1120 are,
```json
{
    "id": 1188,
    "code": "4190.422",
    "name": "IT-리더십세미나",
    "type": "전선",
    "field": null,
    "grade": 4,
    "credit": 1,
    "college": 3,
    "department": 6,
    "major": null
}
```
```json
{
    "id": 1120,
    "code": "400.320",
    "name": "공학연구의 실습 1",
    "type": "전선",
    "field": null,
    "grade": 3,
    "credit": 1,
    "college": 3,
    "department": 6,
    "major": null
}
```

I think whenever you make new ListAPIView or ListCreateAPIView, extending FilterAPIView too will be helpful for searching with various options.

### Etc
I added APIViews of Course, Lecture, College, Department, Major and, accordingly, serializers and urls of them.