### PR TITLE
Enable Email Confirmation

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -105,6 +105,14 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+# Email confirmation
+
+EMAIL_USE_TLS = True
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_HOST_USER = 'snuttrs@gmail.com'
+EMAIL_HOST_PASSWORD = 'throdnjstlfshekq'
+EMAIL_PORT = 587
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.0/topics/i18n/

--- a/backend/ttrs/templates/acc_active_email.html
+++ b/backend/ttrs/templates/acc_active_email.html
@@ -1,0 +1,6 @@
+{% autoescape off %}
+Hi {{ user.username }},
+Please click on the link to confirm your registration,
+
+http://{{ domain }}{% url 'activate' uidb64=uid token=token %}
+{% endautoescape %}

--- a/backend/ttrs/tokens.py
+++ b/backend/ttrs/tokens.py
@@ -1,0 +1,12 @@
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+from django.utils import six
+
+
+class TokenGenerator(PasswordResetTokenGenerator):
+    def _make_hash_value(self, student, timestamp):
+        return six.text_type(student.pk) + \
+               six.text_type(timestamp) + \
+               six.text_type(student.is_active)
+
+
+account_activation_token = TokenGenerator()

--- a/backend/ttrs/urls.py
+++ b/backend/ttrs/urls.py
@@ -1,3 +1,4 @@
+from django.conf.urls import url
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
 
@@ -7,6 +8,7 @@ urlpatterns = [
     path('students/', views.StudentList.as_view()),
     path('students/signup/', views.StudentCreate.as_view()),
     path('students/my/', views.StudentDetail.as_view()),
+    url(r'^activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$', views.activate, name='activate'),
 
     path('courses/', views.CourseList.as_view()),
     path('courses/<int:pk>/', views.CourseDetail.as_view()),

--- a/backend/ttrs/views.py
+++ b/backend/ttrs/views.py
@@ -62,7 +62,8 @@ class StudentCreate(generics.CreateAPIView):
     permission_classes = (AllowAny,)
 
     def perform_create(self, serializer):
-        student = serializer.save(is_active=False)
+        student = serializer.save()
+        #student = serializer.save(is_active=False) Just commented out for development environment
         current_site = get_current_site(self.request)
         mail_subject = 'Activate your account.'
         message = render_to_string('acc_active_email.html', {


### PR DESCRIPTION
If a student has signed up, the student cannot sign in immediately.
When a student signed up, the backend will send a confirmation mail to the student's SNU account of  automatically.
Once the student click the link in the confirmation mail, since then, the student can sign in.

I made a google account for sender of the email confirmation. Please see `settings.py`.

**BUT**, I wonder if we should disable this feature because it is expected to be troublesome when development and test.
I can make a student able to sign in even if the student has not confirmed email account, by changing only one line of the code.
So, please give me your opinions.
I'll put them together and modify the code.