### PR TITLE
Evaluation: author-lecture unique together

### DIFF
--- a/backend/ttrs/models.py
+++ b/backend/ttrs/models.py
@@ -117,6 +117,9 @@ class Evaluation(models.Model):
     def __str__(self):
         return '{}-{}'.format(self.lecture, self.author)
 
+    class Meta:
+        unique_together = ('author', 'lecture')
+
 
 class TimeTable(models.Model):
     title = models.CharField(max_length=100, default='time table', blank=True)

--- a/backend/ttrs/serializers.py
+++ b/backend/ttrs/serializers.py
@@ -124,7 +124,7 @@ class EvaluationSerializer(serializers.ModelSerializer):
         if self.instance is not None:
             return lecture
 
-        # Should not be
+        # Only one evaluation per lecture
         username = self.context['request'].user.username
         student = Student.objects.get_by_natural_key(username)
         evaluation = Evaluation.objects.filter(author=student, lecture=lecture).first()

--- a/backend/ttrs/serializers.py
+++ b/backend/ttrs/serializers.py
@@ -119,6 +119,20 @@ class EvaluationSerializer(serializers.ModelSerializer):
             raise ValidationError("The rate should be an integer between 1 and 10 inclusive.")
         return rate
 
+    def validate_lecture(self, lecture):
+        # ignore PUT, PATCH
+        if self.instance is not None:
+            return lecture
+
+        # Should not be
+        username = self.context['request'].user.username
+        student = Student.objects.get_by_natural_key(username)
+        evaluation = Evaluation.objects.filter(author=student, lecture=lecture).first()
+        if evaluation is not None:
+            raise ValidationError('You can make at most one evaluation per lecture. '
+                                  'Existing evaluation id: {}'.format(evaluation.id))
+        return lecture
+
 
 class EvaluationDetailSerializer(EvaluationSerializer):
     lecture = serializers.ReadOnlyField(source='lecture.id')


### PR DESCRIPTION
An author can make at most one evaluation per lecture. If a student tried to post second evaluation for same lecture, the response will be a bad request. And, the error message includes the already existing evaluation id for the lecture.

**Example**
```json
HTTP 400 Bad Request
Allow: GET, POST, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "lecture": [
        "You can make at most one evaluation per lecture. Existing evaluation id: 19"
    ]
}
```

This pull request include a **new migration**.
Before execute migrate, **make sure** your db does not have evaluations which share same author and same lecture, or the migrating will yield some errors.
You had better to drop the whole _Evaluation_ table.
I recommend to use `/manager/tables/` or Django admin site.