### PR TITLE
Created Rating field on Lecture model

### DIFF
--- a/backend/ttrs/models.py
+++ b/backend/ttrs/models.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import User, UserManager
 from django.db import models
 from django.conf import settings
-from django.db.models import Lookup, Field
+from django.db.models import Lookup, Field, Avg
 
 
 @Field.register_lookup
@@ -58,6 +58,15 @@ class Lecture(models.Model):
     instructor = models.CharField(max_length=20)
     note = models.TextField(blank=True)
 
+    rating = models.FloatField(default=0)
+
+    # def save(self, *args, **kwargs):
+    #     if self.evaluations.count():
+    #         self.rating = sum([e.rate for e in self.evaluations.all()])/self.evaluations.count()
+    #     else:
+    #         self.rating = 0
+    #     super(Lecture, self).save(*args, **kwargs)
+
     @staticmethod
     def have_same_course(lectures):
         codes = set()
@@ -113,6 +122,15 @@ class Evaluation(models.Model):
     rate = models.PositiveSmallIntegerField()
     comment = models.TextField()
     like_it = models.ManyToManyField('ttrs.Student', related_name='like_its', blank=True)
+
+    def save(self, *args, **kwargs):
+        print('asdf')
+        if self.lecture.evaluations.count():
+            self.lecture.rating = self.lecture.evaluations.aggregate(Avg('rate'))['rate__avg']
+        else:
+            self.lecture.rating = 0
+        self.lecture.save()
+        models.Model.save(self, *args, **kwargs)
 
     def __str__(self):
         return '{}-{}'.format(self.lecture, self.author)

--- a/backend/ttrs/serializers.py
+++ b/backend/ttrs/serializers.py
@@ -92,14 +92,6 @@ class TimeSlotSerializer(serializers.ModelSerializer):
 class LectureSerializer(serializers.ModelSerializer):
     course = CourseSerializer()
     time_slots = TimeSlotSerializer(many=True)
-    rating = serializers.SerializerMethodField()
-
-    def get_rating(self, obj):
-        evaluations = obj.evaluations.all()
-        if len(evaluations):
-            return sum([e.rate for e in evaluations])/len(evaluations)
-        else:
-            return 0
 
     class Meta:
         model = Lecture

--- a/backend/ttrs/views.py
+++ b/backend/ttrs/views.py
@@ -36,13 +36,24 @@ class FilterAPIView(generics.GenericAPIView):
     """
 
     def filter_queryset(self, queryset):
+        ordering = None
         options = {}
         for key, value in self.request.query_params.items():
+            if key == 'order_by' and value:
+                try:
+                    queryset.filter(**{value[value[0]=='-':]+'__isnull': 'True'})
+                    ordering = value
+                except (FieldError, ValueError) as e:
+                    print(e)
+                    pass
+                continue
             try:
                 queryset.filter(**{key: value})
                 options.update({key: value})
             except (FieldError, ValueError):
                 pass
+        if ordering:
+            return queryset.filter(**options).order_by(ordering)
         return queryset.filter(**options)
 
 

--- a/backend/ttrs/views.py
+++ b/backend/ttrs/views.py
@@ -25,14 +25,14 @@ from .models import Student, College, Department, Major, Course, Lecture, Evalua
 from .recommend import recommend
 
 
-class FilterAPIView(generics.GenericAPIView):
+class FilterOrderAPIView(generics.GenericAPIView):
     """
-    Custom supporting APIView for filtering queryset based on query_params.
+    Custom supporting APIView for filtering and ordering queryset based on query_params.
 
-    By extending this class, the APIView will automatically filter queryset if the request
-    has query_params.
-    Keys of the query_params MUST be a valid key of the function 'QuerySet.filter', or
-    raises ParseError with status 400.
+    By extending this class, the APIView will automatically filter and order queryset
+    if the request has query_params.
+    Keys of the query_params that is not valid for the function 'QuerySet.filter', except 'order_by', would be ignored.
+    The value of the key 'order_by' that is not valid for the function 'QuerySet.order_by' would be ignored.
     """
 
     def filter_queryset(self, queryset):
@@ -107,7 +107,7 @@ class StudentDetail(generics.RetrieveUpdateDestroyAPIView):
         return Student.objects.get_by_natural_key(self.request.user.username)
 
 
-class CourseList(FilterAPIView, generics.ListAPIView):
+class CourseList(FilterOrderAPIView, generics.ListAPIView):
     queryset = Course.objects.all()
     serializer_class = CourseSerializer
     permission_classes = (IsAuthenticated,)
@@ -120,7 +120,7 @@ class CourseDetail(generics.RetrieveAPIView):
     permission_classes = (IsAuthenticated,)
 
 
-class LectureList(FilterAPIView, generics.ListAPIView):
+class LectureList(FilterOrderAPIView, generics.ListAPIView):
     queryset = Lecture.objects.all()
     serializer_class = LectureSerializer
     permission_classes = (IsAuthenticated,)
@@ -133,7 +133,7 @@ class LectureDetail(generics.RetrieveAPIView):
     permission_classes = (IsAuthenticated,)
 
 
-class EvaluationList(FilterAPIView, generics.ListCreateAPIView):
+class EvaluationList(FilterOrderAPIView, generics.ListCreateAPIView):
     queryset = Evaluation.objects.all()
     serializer_class = EvaluationSerializer
     permission_classes = (IsAuthenticated, IsStudentOrReadOnly)
@@ -168,7 +168,7 @@ class EvaluationLikeIt(generics.RetrieveDestroyAPIView):
         return Response(serializer.data)
 
 
-class MyTimeTableList(FilterAPIView, generics.ListCreateAPIView):
+class MyTimeTableList(FilterOrderAPIView, generics.ListCreateAPIView):
     """
     If the student have a TimeTable with given year and semester already,
     the existing TimeTable will be overwritten by new TimeTable.
@@ -197,7 +197,7 @@ class MyTimeTableDetail(generics.RetrieveUpdateDestroyAPIView):
         return MyTimeTable.objects.filter(owner__username=self.request.user.username)
 
 
-class BookmarkedTimeTableList(FilterAPIView, generics.ListCreateAPIView):
+class BookmarkedTimeTableList(FilterOrderAPIView, generics.ListCreateAPIView):
     serializer_class = BookmarkedTimeTableSerializer
     permission_classes = (IsAuthenticated, IsStudent)
 
@@ -216,7 +216,7 @@ class BookmarkedTimeTableDetail(generics.RetrieveUpdateDestroyAPIView):
         return BookmarkedTimeTable.objects.filter(owner__username=self.request.user.username)
 
 
-class ReceivedTimeTableList(FilterAPIView, generics.ListAPIView):
+class ReceivedTimeTableList(FilterOrderAPIView, generics.ListAPIView):
     serializer_class = ReceivedTimeTableSerializer
     permission_classes = (IsAuthenticated, IsStudent)
 
@@ -325,19 +325,19 @@ class SemesterList(generics.ListAPIView):
         return years_semesters
 
 
-class CollegeList(FilterAPIView, generics.ListAPIView):
+class CollegeList(FilterOrderAPIView, generics.ListAPIView):
     queryset = College.objects.all()
     serializer_class = CollegeSerializer
     permission_classes = (AllowAny,)
 
 
-class DepartmentList(FilterAPIView, generics.ListAPIView):
+class DepartmentList(FilterOrderAPIView, generics.ListAPIView):
     queryset = Department.objects.all()
     serializer_class = DepartmentSerializer
     permission_classes = (AllowAny,)
 
 
-class MajorList(FilterAPIView, generics.ListAPIView):
+class MajorList(FilterOrderAPIView, generics.ListAPIView):
     queryset = Major.objects.all()
     serializer_class = MajorSerializer
     permission_classes = (AllowAny,)


### PR DESCRIPTION
## Rating field of Lecture model
There is a new field `rating` on `Lecture` model.
Therefore, we can use this `rating` when search lectures by params.
The `rating` field is updated automatically whenever the related `Evaluation` instance is created, modified and deleted.

## Ordering by request param
I extend `FilterAPIView` to `FilterOrderAPIView` providing ordering queryset feature.
You can order the queryset by sending a param of key `order_by`.
The value should be a valid field name, or would be ignored.
<br>
- If you send this request
```json
GET /ttrs/lectures/?course__name__contains=C&order_by=course__credit
```
The response would be a list of lectures that have 'C' in their course name and they would be ordered by credit of the course, in ascending order.
<br>
- Likely,
```json
GET /ttrs/lectures/?course__name__contains=C&order_by=rating
```
This request would yield filtered lectures which are ordered by rating in ascending.
<br>
- If you want to sort in descending order, just add a prefix`'-'` at the value.
```json
GET /ttrs/lectures/?course__name__contains=C&order_by=-course__grade
```
Responded lectures would be sorted by descending order based on the grade of the course.
<br>
- Of course, the ordering also supports non-numeric keys.
```json
GET /ttrs/lectures/?course__name__contains=C&order_by=course__name
```
This request is completely valid.