### PR TITLE
Add two fields

### DIFF
--- a/backend/ttrs/models.py
+++ b/backend/ttrs/models.py
@@ -122,6 +122,7 @@ class Evaluation(models.Model):
     rate = models.PositiveSmallIntegerField()
     comment = models.TextField()
     like_it = models.ManyToManyField('ttrs.Student', related_name='like_its', blank=True)
+    evaluated_at = models.DateTimeField(auto_now_add=True)
 
     def save(self, *args, **kwargs):
         if self.lecture.evaluations.count():

--- a/backend/ttrs/serializers.py
+++ b/backend/ttrs/serializers.py
@@ -131,6 +131,8 @@ class EvaluationDetailSerializer(EvaluationSerializer):
 
 
 class TimeTableSerializer(serializers.ModelSerializer):
+    credit_sum = serializers.SerializerMethodField(read_only=True)
+
     class Meta:
         model = TimeTable
         fields = '__all__'
@@ -159,6 +161,9 @@ class TimeTableSerializer(serializers.ModelSerializer):
         if hasattr(self, 'semester'):
             validated_data['semester'] = self.semester
         return super(TimeTableSerializer, self).create(validated_data)
+
+    def get_credit_sum(self, obj):
+        return sum([lecture.course.credit for lecture in obj.lectures.all()])
 
 
 class MyTimeTableSerializer(TimeTableSerializer):


### PR DESCRIPTION
add `evaluated_at` field to `Evaluation` model
add `credit_sum` field to `TimeTableSerializer`

# IMPORTANT
### If you don't want to drop the database due to somewhat errors, please follow these steps to manually update database table.

1. Execute `$ python3 manage.py makemigration ttrs`
2. Execute `$ python3 manage.py migrate`
3. You would get this message.
```
You are trying to add the field 'evaluated_at' with 'auto_now_add=True' to evaluation without a default; the database needs something to populate existing rows.

 1) Provide a one-off default now (will be set on all existing rows)
 2) Quit, and let me add a default in models.py
```
4. Type `1`.
5. You would get this message.
```
Please enter the default value now, as valid Python
You can accept the default 'timezone.now' by pressing 'Enter' or you can provide another value.
The datetime and django.utils.timezone modules are available, so you can do e.g. timezone.now
Type 'exit' to exit this prompt
```
6. Just type enter.
7. The migration would be performed well.